### PR TITLE
#12474: std.fs.Dir.makeOpenPath: optimize case, if path already exists

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1465,6 +1465,37 @@ pub const Dir = struct {
         }
     }
 
+    fn openDirAccessMaskWWrapper (self: Dir, sub_path: []const u8, access_mask: u32, no_follow: bool) OpenError!Dir {
+        const w = os.windows;
+        var end_index: usize = sub_path.len;
+
+        return while (true) {
+            const sub_path_w = try w.sliceToPrefixedFileW(sub_path[0..end_index]);
+            const result = self.openDirAccessMaskW(sub_path_w.span().ptr, access_mask, .{
+                .no_follow = no_follow,
+                .create = true,
+            }) catch |err| switch (err) {
+                error.FileNotFound => {
+                    // march end_index backward until next path component
+                    while (true) {
+                        if (end_index == 0) return err;
+                        end_index -= 1;
+                        if (path.isSep(sub_path[end_index])) break;
+                    }
+                    continue;
+                },
+                else => return err
+            };
+
+            if (end_index == sub_path.len) return result;
+            // march end_index forward until next path component
+            while (true) {
+                end_index += 1;
+                if (end_index == sub_path.len or path.isSep(sub_path[end_index])) break;
+            }
+        };
+    }
+
     /// This function performs `makePath`, followed by `openDir`.
     /// If supported by the OS, this operation is atomic. It is not atomic on
     /// all operating systems.
@@ -1472,14 +1503,10 @@ pub const Dir = struct {
         return switch(builtin.os.tag) {
             .windows => {
                 const w = os.windows;
-                const sub_path_w = try w.sliceToPrefixedFileW(sub_path);
-
                 const base_flags = w.STANDARD_RIGHTS_READ | w.FILE_READ_ATTRIBUTES | w.FILE_READ_EA |
                     w.SYNCHRONIZE | w.FILE_TRAVERSE;
-                return self.openDirAccessMaskW(sub_path_w.span().ptr, base_flags, .{
-                    .no_follow = open_dir_options.no_follow,
-                    .create = true,
-                });
+
+                return self.openDirAccessMaskWWrapper(sub_path, base_flags, open_dir_options.no_follow);
             },
             else => {
                 return self.openDir(sub_path, open_dir_options) catch {
@@ -1497,15 +1524,11 @@ pub const Dir = struct {
         return switch(builtin.os.tag) {
             .windows => {
                 const w = os.windows;
-                const sub_path_w = try w.sliceToPrefixedFileW(sub_path);
-
                 const base_flags = w.STANDARD_RIGHTS_READ | w.FILE_READ_ATTRIBUTES | w.FILE_READ_EA |
                     w.SYNCHRONIZE | w.FILE_TRAVERSE | w.FILE_LIST_DIRECTORY;
+                
                 return IterableDir{
-                    .dir = try self.openDirAccessMaskW(sub_path_w.span().ptr, base_flags, .{
-                        .no_follow = open_dir_options.no_follow,
-                        .create = true,
-                    }),
+                    .dir = try self.openDirAccessMaskWWrapper(sub_path, base_flags, open_dir_options.no_follow)
                 };
             },
             else => {
@@ -1835,6 +1858,7 @@ pub const Dir = struct {
             null,
             0,
         );
+        
         switch (rc) {
             .SUCCESS => return result,
             .OBJECT_NAME_INVALID => unreachable,

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -1469,18 +1469,52 @@ pub const Dir = struct {
     /// If supported by the OS, this operation is atomic. It is not atomic on
     /// all operating systems.
     pub fn makeOpenPath(self: Dir, sub_path: []const u8, open_dir_options: OpenDirOptions) !Dir {
-        // TODO improve this implementation on Windows; we can avoid 1 call to NtClose
-        try self.makePath(sub_path);
-        return self.openDir(sub_path, open_dir_options);
+        return switch(builtin.os.tag) {
+            .windows => {
+                const w = os.windows;
+                const sub_path_w = try w.sliceToPrefixedFileW(sub_path);
+
+                const base_flags = w.STANDARD_RIGHTS_READ | w.FILE_READ_ATTRIBUTES | w.FILE_READ_EA |
+                    w.SYNCHRONIZE | w.FILE_TRAVERSE;
+                return self.openDirAccessMaskW(sub_path_w.span().ptr, base_flags, .{
+                    .no_follow = open_dir_options.no_follow,
+                    .create = true,
+                });
+            },
+            else => {
+                return self.openDir(sub_path, open_dir_options) catch {
+                    try self.makePath(sub_path);
+                    return self.openDir(sub_path, open_dir_options);
+                };
+            }
+        };
     }
 
     /// This function performs `makePath`, followed by `openIterableDir`.
     /// If supported by the OS, this operation is atomic. It is not atomic on
     /// all operating systems.
     pub fn makeOpenPathIterable(self: Dir, sub_path: []const u8, open_dir_options: OpenDirOptions) !IterableDir {
-        // TODO improve this implementation on Windows; we can avoid 1 call to NtClose
-        try self.makePath(sub_path);
-        return self.openIterableDir(sub_path, open_dir_options);
+        return switch(builtin.os.tag) {
+            .windows => {
+                const w = os.windows;
+                const sub_path_w = try w.sliceToPrefixedFileW(sub_path);
+
+                const base_flags = w.STANDARD_RIGHTS_READ | w.FILE_READ_ATTRIBUTES | w.FILE_READ_EA |
+                    w.SYNCHRONIZE | w.FILE_TRAVERSE | w.FILE_LIST_DIRECTORY;
+                return IterableDir{
+                    .dir = try self.openDirAccessMaskW(sub_path_w.span().ptr, base_flags, .{
+                        .no_follow = open_dir_options.no_follow,
+                        .create = true,
+                    }),
+                };
+            },
+            else => {
+                return self.openIterableDir(sub_path, open_dir_options) catch {
+                    try self.makePath(sub_path);
+                    return self.openIterableDir(sub_path, open_dir_options);
+                };
+            }
+        };
     }
 
     ///  This function returns the canonicalized absolute pathname of
@@ -1734,7 +1768,10 @@ pub const Dir = struct {
         const base_flags = w.STANDARD_RIGHTS_READ | w.FILE_READ_ATTRIBUTES | w.FILE_READ_EA |
             w.SYNCHRONIZE | w.FILE_TRAVERSE;
         const flags: u32 = if (iterable) base_flags | w.FILE_LIST_DIRECTORY else base_flags;
-        var dir = try self.openDirAccessMaskW(sub_path_w, flags, args.no_follow);
+        var dir = try self.openDirAccessMaskW(sub_path_w, flags, .{
+            .no_follow = args.no_follow,
+            .create = false,
+        });
         return dir;
     }
 
@@ -1757,7 +1794,12 @@ pub const Dir = struct {
         return Dir{ .fd = fd };
     }
 
-    fn openDirAccessMaskW(self: Dir, sub_path_w: [*:0]const u16, access_mask: u32, no_follow: bool) OpenError!Dir {
+    const OpenDirAccessMaskWOptions = struct {
+        no_follow: bool,
+        create: bool,
+    };
+
+    fn openDirAccessMaskW(self: Dir, sub_path_w: [*:0]const u16, access_mask: u32, flags: OpenDirAccessMaskWOptions) OpenError!Dir {
         const w = os.windows;
 
         var result = Dir{
@@ -1778,7 +1820,7 @@ pub const Dir = struct {
             .SecurityDescriptor = null,
             .SecurityQualityOfService = null,
         };
-        const open_reparse_point: w.DWORD = if (no_follow) w.FILE_OPEN_REPARSE_POINT else 0x0;
+        const open_reparse_point: w.DWORD = if (flags.no_follow) w.FILE_OPEN_REPARSE_POINT else 0x0;
         var io: w.IO_STATUS_BLOCK = undefined;
         const rc = w.ntdll.NtCreateFile(
             &result.fd,
@@ -1786,9 +1828,9 @@ pub const Dir = struct {
             &attr,
             &io,
             null,
-            0,
+            w.FILE_ATTRIBUTE_NORMAL,
             w.FILE_SHARE_READ | w.FILE_SHARE_WRITE,
-            w.FILE_OPEN,
+            if (flags.create) w.FILE_OPEN_IF else w.FILE_OPEN,
             w.FILE_DIRECTORY_FILE | w.FILE_SYNCHRONOUS_IO_NONALERT | w.FILE_OPEN_FOR_BACKUP_INTENT | open_reparse_point,
             null,
             0,


### PR DESCRIPTION
Uses a single NtCreateFile syscall on windows.

Closes ziglang#12474. Thanks to @joedavis and @matu3ba.